### PR TITLE
Show field array level errors

### DIFF
--- a/src/forms/FieldArray/KeyValueFieldArray.js
+++ b/src/forms/FieldArray/KeyValueFieldArray.js
@@ -1,85 +1,83 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {
-  Button,
-  Col,
-  FormControl,
-  Glyphicon,
-  InputGroup,
-  Tooltip,
-} from 'react-bootstrap';
+import { Button, Col, InputGroup, } from 'react-bootstrap';
 import { FormSection } from 'redux-form';
-import {
-  MagicRow,
-  FormField,
-} from '../..';
+import { FormField, MagicRow, } from '../..';
+import FontAwesome from 'react-fontawesome';
+import { fieldArrayButtonBsStyle, fieldArrayMeta } from './meta';
 
 /**
  * Component that renders a key-value field array.
  */
 const KeyValueFieldArray = ({
   fields, meta, label, help, disabled, keyField, valueField, emptyMessage,
-}) => (
-  <FormField
-    label={(
-      <span>
+}) => {
+  const buttonBsStyle = fieldArrayButtonBsStyle(meta);
+
+  return (
+    <FormField
+      label={(
+        <span>
         {label}
 
-        <Button
-          bsSize="xs"
-          style={{ marginLeft: 6 }}
-          disabled={disabled}
-          onClick={() => fields.push({})}
-        >
-          <Glyphicon glyph="plus" />
+          <Button
+            bsSize="xs"
+            bsStyle={buttonBsStyle}
+            style={{ marginLeft: 6 }}
+            disabled={disabled}
+            onClick={() => fields.push({})}
+          >
+          <FontAwesome name="plus" />
         </Button>
       </span>
-    )}
-    help={help}
-    meta={meta}
-  >
-    <MagicRow colSizeKey="md">
-      {fields.map((field, idx) => (
-        <Col
-          key={field}
-          xs={12}
-          sm={6}
-          md={4}
-          style={{ marginBottom: 15 }}
-        >
-          <FormSection name={field}>
-            <InputGroup>
-              {keyField}
+      )}
+      help={help}
+      meta={fieldArrayMeta(meta)}
+    >
+      <MagicRow colSizeKey="md">
+        {fields.map((field, idx) => (
+          <Col
+            key={field}
+            xs={12}
+            sm={6}
+            md={4}
+            style={{ marginBottom: 15 }}
+          >
+            <FormSection name={field}>
+              <InputGroup>
+                {keyField}
 
-              <InputGroup.Addon style={{
-                borderLeft: 0,
-                borderRight: 0,
-                padding: '6px 3px',
-              }}
-              />
+                <InputGroup.Addon style={{
+                  borderLeft: 0,
+                  borderRight: 0,
+                  padding: '6px 3px',
+                }}
+                />
 
-              {valueField}
+                {valueField}
 
-              <InputGroup.Button>
-                <Tooltip text="Remove" placement="top">
+                <InputGroup.Button>
+                  {/* Do not use a Tooltip here for now. It's breaking the style since InputGroup.Button apply styles
+                  * to children directly. In Bootstrap 4 InputGroup.Button was also removed, so that is going to
+                  * change anyway. */}
                   <Button
+                    bsStyle={buttonBsStyle}
                     disabled={disabled}
                     onClick={() => fields.remove(idx)}
                   >
-                    <Glyphicon glyph="remove" />
+                    <FontAwesome name="remove" />
                   </Button>
-                </Tooltip>
-              </InputGroup.Button>
-            </InputGroup>
-          </FormSection>
-        </Col>
-      ))}
-    </MagicRow>
+                </InputGroup.Button>
+              </InputGroup>
+            </FormSection>
+          </Col>
+        ))}
+      </MagicRow>
 
-    {emptyMessage && fields.length === 0 && emptyMessage}
-    <FormControl.Feedback />
-  </FormField>
-);
+      {emptyMessage && fields.length === 0 && emptyMessage}
+    </FormField>
+  );
+}
 
 KeyValueFieldArray.propTypes = {
   /**

--- a/src/forms/FieldArray/SectionFieldArray/SectionFieldArray.js
+++ b/src/forms/FieldArray/SectionFieldArray/SectionFieldArray.js
@@ -1,15 +1,9 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import FontAwesome from 'react-fontawesome';
-import {
-  FormControl,
-} from 'react-bootstrap';
-import {
-  DropdownButton,
-  FormField,
-  Tooltip,
-} from '../../..';
+import { DropdownButton, FormField, Tooltip, } from '../../..';
 import FieldArrayElement from '../FieldArrayElement';
+import { fieldArrayMeta, fieldArrayButtonBsStyle } from '../meta';
 
 /**
  * Component that renders a section field array using the provided innerComponent prop as its elements.
@@ -187,6 +181,7 @@ class SectionFieldArray extends Component {
         emptyMessage,
       } = this.props;
 
+    const buttonBsStyle = fieldArrayButtonBsStyle(meta);
     const pushItem = (selected) => {
       const item = onAdd ? onAdd(selected) : initialFieldValue;
       fields.push(item);
@@ -202,7 +197,7 @@ class SectionFieldArray extends Component {
           </span>
         )}
         help={help}
-        meta={meta}
+        meta={fieldArrayMeta(meta)}
       >
         {fieldArray}
 
@@ -214,14 +209,13 @@ class SectionFieldArray extends Component {
             className="text-center"
             title={<FontAwesome name="plus" />}
             style={{ display: 'block' }}
-            bsStyle="primary"
+            bsStyle={buttonBsStyle}
             disabled={disabled || (addChoices && addChoices.length === 0)}
             onSelect={pushItem}
           >
             {addChoices}
           </DropdownButton>
         </Tooltip>
-        <FormControl.Feedback />
       </FormField>
     );
   }

--- a/src/forms/FieldArray/SortableSectionFieldArray/SortableSectionFieldArray.js
+++ b/src/forms/FieldArray/SortableSectionFieldArray/SortableSectionFieldArray.js
@@ -2,16 +2,10 @@ import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import FontAwesome from 'react-fontawesome';
-import {
-  FormControl,
-} from 'react-bootstrap';
-import {
-  DropdownButton,
-  FormField,
-  Tooltip,
-} from '../../..';
+import { DropdownButton, FormField, Tooltip, } from '../../..';
 import FieldArrayElement from '../FieldArrayElement';
 import SortableList from './SortableList';
+import { fieldArrayButtonBsStyle, fieldArrayMeta } from '../meta';
 
 
 /**
@@ -210,6 +204,7 @@ class VerticalFieldArray extends Component {
         emptyMessage,
       } = this.props;
 
+    const buttonBsStyle = fieldArrayButtonBsStyle(meta);
     const pushItem = (selected) => {
       const item = onAdd ? onAdd(selected) : initialFieldValue;
       fields.push(item);
@@ -225,7 +220,7 @@ class VerticalFieldArray extends Component {
           </span>
         )}
         help={help}
-        meta={meta}
+        meta={fieldArrayMeta(meta)}
       >
         <SortableList
           dragHandle
@@ -248,14 +243,13 @@ class VerticalFieldArray extends Component {
             className="text-center"
             title={<FontAwesome name="plus" />}
             style={{ display: 'block' }}
-            bsStyle="primary"
+            bsStyle={buttonBsStyle}
             disabled={disabled || (addChoices && addChoices.length === 0)}
             onSelect={pushItem}
           >
             {addChoices}
           </DropdownButton>
         </Tooltip>
-        <FormControl.Feedback />
       </FormField>
     );
   }

--- a/src/forms/FieldArray/meta.js
+++ b/src/forms/FieldArray/meta.js
@@ -1,0 +1,17 @@
+function hasFieldArrayError(meta) {
+  return (meta.dirty === true || meta.submitFailed === true) && !_.isEmpty(meta.error);
+}
+
+export function fieldArrayButtonBsStyle(meta) {
+  return hasFieldArrayError(meta) ? 'danger' : 'primary';
+}
+
+export function fieldArrayMeta(meta) {
+  return {
+    ...meta,
+    // Field arrays don't have touched in meta, so we emulate that with meta.dirty, meta.submitFailed and meta.error.
+    // The idea here is to signalize field array level errors, which weren't displayed before, while leaving field
+    // success state display for child fields only.
+    touched: hasFieldArrayError(meta),
+  };
+}


### PR DESCRIPTION
Field arrays don't have touched in meta, so we emulate that with meta.dirty, meta.submitFailed and meta.error. The idea here is to signalize field array level errors, which weren't displayed before, while leaving field success state display for child fields only.

![image](https://user-images.githubusercontent.com/375149/56300159-b9361100-6135-11e9-9c4a-3d1993b51f8e.png)

![image](https://user-images.githubusercontent.com/375149/56300136-ab808b80-6135-11e9-9206-919031ed89e1.png)
