### PR TITLE
Specify repo for docs deploy

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -50,7 +50,7 @@
     "storybook": "start-storybook -p 6006",
     "format": "prettier --write '**/*.js'",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "deploy": "npm run build-all&& gh-pages -d public --"
+    "deploy": "npm run build-all && gh-pages -d public --repo git@github.com:kayak/bandit-pouch.git"
   },
   "devDependencies": {
     "gh-pages": "^2.0.1",


### PR DESCRIPTION
This guarantees that we always deploy to the right repo, even when origin refers to a fork.