### PR TITLE
Add id to CheckboxField

### DIFF
--- a/docs/stories/test/__snapshots__/storyshots.test.js.snap
+++ b/docs/stories/test/__snapshots__/storyshots.test.js.snap
@@ -32,14 +32,14 @@ exports[`MyStoryshots Forms|CheckboxField Interactive Mode 1`] = `
                   checked={false}
                   className="form-check-input"
                   disabled={false}
-                  id={null}
+                  id="formField"
                   name="formField"
                   onChange={[Function]}
                   type="checkbox"
                 />
                 <label
                   className="form-check-label"
-                  htmlFor={null}
+                  htmlFor="formField"
                   title=""
                   type="checkbox"
                 >
@@ -704,14 +704,14 @@ exports[`MyStoryshots Forms|CheckboxField default 1`] = `
                   checked={false}
                   className="form-check-input"
                   disabled={false}
-                  id={null}
+                  id="formField"
                   name="formField"
                   onChange={[Function]}
                   type="checkbox"
                 />
                 <label
                   className="form-check-label"
-                  htmlFor={null}
+                  htmlFor="formField"
                   title=""
                   type="checkbox"
                 >
@@ -1347,14 +1347,14 @@ exports[`MyStoryshots Forms|CheckboxField with disabled 1`] = `
                   checked={false}
                   className="form-check-input"
                   disabled={true}
-                  id={null}
+                  id="formField"
                   name="formField"
                   onChange={[Function]}
                   type="checkbox"
                 />
                 <label
                   className="form-check-label"
-                  htmlFor={null}
+                  htmlFor="formField"
                   title=""
                   type="checkbox"
                 >

--- a/src/forms/CheckboxField.js
+++ b/src/forms/CheckboxField.js
@@ -21,6 +21,7 @@ const CheckboxField = ({
 }) => (
   <FormField id={input.id} help={help} meta={meta}>
     <Form.Check
+      id={input.id || input.name}
       type="checkbox"
       name={input.name}
       label={label}


### PR DESCRIPTION
Adding the id to the FormCheck component will also add it to FormCheckInput and as "for"-attribute to FormCheckLabel. This will make the label of the checkbox clickable and is also useful for adding custom styles to checkboxes (e.g. using label::before to create a custom checkbox).