### PR TITLE
Set hide as enabled: false in Tooltip.js popper config. 

### DIFF
--- a/src/ui/Tooltip.js
+++ b/src/ui/Tooltip.js
@@ -18,6 +18,9 @@ const Tooltip = ({ text, children, ...props }) => (
         preventOverflow: {
           enabled: false,
         },
+        hide: {
+          enabled: false,
+        },
       },
     }}
     {...props}


### PR DESCRIPTION
Fixes #94.